### PR TITLE
Lexicon

### DIFF
--- a/src/services/__tests__/lexicon.service.test.ts
+++ b/src/services/__tests__/lexicon.service.test.ts
@@ -1,6 +1,7 @@
 import { getTestDataSource } from '../../data-source';
 import getSingletons from '../../singletons';
-import { Lexicon } from '../lexicon.service';
+import { BaseType, CRUDService } from '../crud-service';
+import LexiconService from '../lexicon.service';
 
 describe('LexiconService', () => {
   const getService = () =>
@@ -9,19 +10,59 @@ describe('LexiconService', () => {
       .then(({ lexiconService }) => lexiconService);
 
   describe('Core Types', () => {
-    it('Creates lexica', async () => {
-      const service = await getService();
+    type ServiceProvider<T extends BaseType> = (
+      s: LexiconService,
+    ) => CRUDService<T>;
+    type TestParams<T extends BaseType> = {
+      type: string;
+      data: Partial<T>;
+      provider: ServiceProvider<T>;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const args: TestParams<any>[] = [
+      {
+        type: 'lexica',
+        data: { name: 'Greek' },
+        provider: (s: LexiconService) => s.lexica,
+      },
+      {
+        type: 'lexical categories',
+        data: { name: 'noun' },
+        provider: (s: LexiconService) => s.lexicalCategories,
+      },
+      {
+        type: 'grammatical categories',
+        data: { name: 'case' },
+        provider: (s: LexiconService) => s.grammaticalCategories,
+      },
+      {
+        type: 'grammemes',
+        data: { name: 'nominative' },
+        provider: (s: LexiconService) => s.grammemes,
+      },
+      {
+        type: 'lexemes',
+        data: { lemma: 'οἶκος' },
+        provider: (s: LexiconService) => s.lexemes,
+      },
+      {
+        type: 'word forms',
+        data: { text: 'οἶκοι' },
+        provider: (s: LexiconService) => s.wordForms,
+      },
+    ];
 
-      const d: Partial<Lexicon> = {
-        name: 'foo',
-      };
+    it.each(args)('Creates $type', async ({ data, provider }) => {
+      const lexiconService = await getService();
+      const service = provider(lexiconService);
 
-      const created = await service.lexica.create(d);
-      expect(created).toMatchObject(d);
+      const created = await service.create(data);
+      expect(created).toMatchObject(data);
 
-      const found = await service.lexica.findOneBy({ id: created.id });
+      const found = await service.findOneBy({ id: created.id });
       expect(found).toMatchObject(created);
     });
+
     it.todo('Creates lexical categories');
     it.todo('Creates grammatical categories');
     it.todo('Creates grammemes');

--- a/src/services/crud-service.ts
+++ b/src/services/crud-service.ts
@@ -1,0 +1,93 @@
+import { NodeService } from './node.service';
+import { Node } from '@/models/node/node.entity';
+import { Schema } from 'yup';
+import { NodeRepository } from '@/repositories/node/node.repository';
+import { FindOptionsWhere } from 'typeorm';
+
+export class CRUDService<T> {
+  constructor(
+    private readonly nodeType: string,
+    private readonly schema: Schema<T>,
+    private readonly nodeService: NodeService,
+    private readonly nodeRepo: NodeRepository,
+  ) {}
+
+  private async ofNode(node: Node): Promise<T> {
+    const props = node.propertyKeys || [];
+    const obj = props.reduce((acc, key) => {
+      let value;
+      try {
+        value = JSON.parse(key.propertyValue.property_value);
+      } catch (err) {
+        console.warn(err);
+      }
+
+      if (value && 'value' in value) {
+        return {
+          ...acc,
+          [key.property_key]: value.value,
+        };
+      } else {
+        return acc;
+      }
+    }, {});
+
+    try {
+      return this.schema.cast({ id: node.id, ...obj });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      const json = JSON.stringify(obj);
+      const desc = JSON.stringify(this.schema.describe());
+      throw new Error(
+        `Failed to cast object "${json}" to schema ${desc}: ${msg}`,
+      );
+    }
+  }
+
+  private findOptsFromWhere(opts: FindOptionsWhere<Node>) {
+    return {
+      where: opts,
+      relations: {
+        propertyKeys: {
+          propertyValue: true,
+        },
+      },
+    };
+  }
+
+  private async findNodeBy(opts: FindOptionsWhere<Node>): Promise<Node[]> {
+    return await this.nodeRepo.repository.find(this.findOptsFromWhere(opts));
+  }
+
+  private async findOneNodeBy(
+    opts: FindOptionsWhere<Node>,
+  ): Promise<Node | null> {
+    return await this.nodeRepo.repository.findOne(this.findOptsFromWhere(opts));
+  }
+
+  async create(obj: Partial<T>): Promise<T> {
+    const node = await this.nodeService.createNodeFromObject(
+      this.nodeType,
+      obj,
+    );
+
+    const entity = await this.findOneNodeBy({ id: node.id });
+    if (entity) {
+      return this.ofNode(entity);
+    } else {
+      throw new Error(
+        `Failed to create node from object: "${JSON.stringify(obj)}"`,
+      );
+    }
+  }
+
+  async findBy(opts: Partial<T>): Promise<T[]> {
+    const nodes = await this.findNodeBy(opts);
+    return Promise.all(nodes.map(this.ofNode));
+  }
+
+  async findOneBy(opts: Partial<T>): Promise<T | null> {
+    const node = await this.findOneNodeBy(opts);
+    return node ? this.ofNode(node) : null;
+  }
+}

--- a/src/services/lexicon.service.ts
+++ b/src/services/lexicon.service.ts
@@ -2,6 +2,7 @@ import { NodeService } from './node.service';
 import { Node } from '@/models/node/node.entity';
 import { InferType, object, Schema, string } from 'yup';
 import { NodeRepository } from '@/repositories/node/node.repository';
+import { FindOptionsWhere } from 'typeorm';
 
 export enum LexiconNodeType {
   Lexicon = 'lexicon',
@@ -23,15 +24,55 @@ export class CRUDService<T> {
 
   private async ofNode(node: Node): Promise<T> {
     const props = node.propertyKeys || [];
-    const obj = props.reduce(
-      (acc, key) => ({
-        ...acc,
-        [key.property_key]: key.propertyValue.property_value,
-      }),
-      {},
-    );
+    const obj = props.reduce((acc, key) => {
+      let value;
+      try {
+        value = JSON.parse(key.propertyValue.property_value);
+      } catch (err) {
+        console.warn(err);
+      }
 
-    return this.schema.cast(obj);
+      if (value && 'value' in value) {
+        return {
+          ...acc,
+          [key.property_key]: value.value,
+        };
+      } else {
+        return acc;
+      }
+    }, {});
+
+    try {
+      return this.schema.cast({ id: node.id, ...obj });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      const json = JSON.stringify(obj);
+      const desc = JSON.stringify(this.schema.describe());
+      throw new Error(
+        `Failed to cast object "${json}" to schema ${desc}: ${msg}`,
+      );
+    }
+  }
+
+  private findOptsFromWhere(opts: FindOptionsWhere<Node>) {
+    return {
+      where: opts,
+      relations: {
+        propertyKeys: {
+          propertyValue: true,
+        },
+      },
+    };
+  }
+
+  private async findNodeBy(opts: FindOptionsWhere<Node>): Promise<Node[]> {
+    return await this.nodeRepo.repository.find(this.findOptsFromWhere(opts));
+  }
+
+  private async findOneNodeBy(
+    opts: FindOptionsWhere<Node>,
+  ): Promise<Node | null> {
+    return await this.nodeRepo.repository.findOne(this.findOptsFromWhere(opts));
   }
 
   async create(obj: Partial<T>): Promise<T> {
@@ -40,16 +81,23 @@ export class CRUDService<T> {
       obj,
     );
 
-    return this.ofNode(node);
+    const entity = await this.findOneNodeBy({ id: node.id });
+    if (entity) {
+      return this.ofNode(entity);
+    } else {
+      throw new Error(
+        `Failed to create node from object: "${JSON.stringify(obj)}"`,
+      );
+    }
   }
 
   async findBy(opts: Partial<T>): Promise<T[]> {
-    const nodes = await this.nodeRepo.repository.findBy(opts);
+    const nodes = await this.findNodeBy(opts);
     return Promise.all(nodes.map(this.ofNode));
   }
 
   async findOneBy(opts: Partial<T>): Promise<T | null> {
-    const node = await this.nodeRepo.repository.findOneBy(opts);
+    const node = await this.findOneNodeBy(opts);
     return node ? this.ofNode(node) : null;
   }
 }

--- a/src/services/lexicon.service.ts
+++ b/src/services/lexicon.service.ts
@@ -1,7 +1,7 @@
 import { NodeService } from './node.service';
 import { InferType, object, Schema, string } from 'yup';
 import { NodeRepository } from '@/repositories/node/node.repository';
-import { CRUDService } from './crud-service';
+import { baseSchema, BaseType, CRUDService } from './crud-service';
 
 export enum LexiconNodeType {
   Lexicon = 'lexicon',
@@ -12,25 +12,46 @@ export enum LexiconNodeType {
   WordForm = 'word_form',
 }
 
-const lexiconSchema = object({
-  id: string().uuid().required(),
-  name: string().min(1).required(),
-});
+const lexiconSchema = baseSchema.concat(
+  object({
+    name: string().min(1).required(),
+  }),
+);
 export type Lexicon = InferType<typeof lexiconSchema>;
 
-const lexicalCategorySchema = object({});
+const lexicalCategorySchema = baseSchema.concat(
+  object({
+    name: string().min(1).required(),
+  }),
+);
 export type LexicalCategory = InferType<typeof lexicalCategorySchema>;
 
-const grammaticalCategorySchema = object({});
+const grammaticalCategorySchema = baseSchema.concat(
+  object({
+    name: string().min(1).required(),
+  }),
+);
 export type GrammaticalCategory = InferType<typeof grammaticalCategorySchema>;
 
-const grammemeSchema = object({});
+const grammemeSchema = baseSchema.concat(
+  object({
+    name: string().min(1).required(),
+  }),
+);
 export type Grammeme = InferType<typeof grammemeSchema>;
 
-const lexemeSchema = object({});
+const lexemeSchema = baseSchema.concat(
+  object({
+    lemma: string().min(1).required(),
+  }),
+);
 export type Lexeme = InferType<typeof lexemeSchema>;
 
-const wordFormSchema = object({});
+const wordFormSchema = baseSchema.concat(
+  object({
+    text: string().min(1).required(),
+  }),
+);
 export type WordForm = InferType<typeof wordFormSchema>;
 
 export default class LexiconService {
@@ -42,8 +63,10 @@ export default class LexiconService {
   public readonly wordForms: CRUDService<WordForm>;
 
   constructor(nodeService: NodeService, nodeRepo: NodeRepository) {
-    const service = <T>(model: LexiconNodeType, schema: Schema<T>) =>
-      new CRUDService(model, schema, nodeService, nodeRepo);
+    const service = <T extends BaseType>(
+      model: LexiconNodeType,
+      schema: Schema<T>,
+    ) => new CRUDService(model, schema, nodeService, nodeRepo);
     this.lexica = service(LexiconNodeType.Lexicon, lexiconSchema);
     this.lexicalCategories = service(
       LexiconNodeType.LexicalCategory,


### PR DESCRIPTION
Adds a `CRUDService` that uses type information from Yup schemas to create `node`, `node_property_key`, and `node_property_value` records in our graph.

Additionally, uses `CRUDService` instances to create types for the lexicon module:

- `Lexicon` is a particular collection of other types
- `LexicalCategory` is a grouping that one or more lexemes can be divided into. For mode languages this will be the same as a 'part of speech', but may also be used to distinguish between types of lexemes that wouldn't fall into a traditional part of speech category.
- `GrammaticalCategory` is a property that can be applied to a lexeme, such as a tense, mood, number, etc.
- `Gramme` is a value that a `GrammaticalCategory` can have, such has `singluar` and `plural` for `number`.
- `Lexeme` is a basic lexical unit for a language. This can also be thought of as a collection of `WordForm`s that all fall under the same entry in the lexicon.
- `WordForm` is a particular derivation of a `Lexeme`.